### PR TITLE
Add python 2/3 trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,13 @@ setup(name='lunardate',
       classifiers = [
                      'Development Status :: 4 - Beta',
                      'Programming Language :: Python',
+                     'Programming Language :: Python :: 2',
+                     'Programming Language :: Python :: 2.7',
+                     'Programming Language :: Python :: 3',
+                     'Programming Language :: Python :: 3.4',
+                     'Programming Language :: Python :: 3.5',
+                     'Programming Language :: Python :: 3.6',
+                     'Programming Language :: Python :: 3.7',
                      'License :: OSI Approved :: GNU General Public License (GPL)',
                      'Operating System :: OS Independent',
                      'Topic :: Software Development :: Libraries :: Python Modules'


### PR DESCRIPTION
Clearly identify this project as supporting python 2 and 3.
This is useful for utility programs like [caniusepython3](https://github.com/brettcannon/caniusepython3#how-do-you-tell-if-a-project-has-been-ported-to-python-3).